### PR TITLE
hotfix/user_service_registry_failure

### DIFF
--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -51,4 +51,4 @@ logging:
 eureka:
   client:
     serviceUrl:
-      defaultZone: "http://registry-service:8761/eureka/"
+      defaultZone: "http://localhost:8761/eureka/"


### PR DESCRIPTION
Modify registry configuration of user service for local development from 'registry-service', which is used in dockerized environment, back to 'localhost'. Otherwise, the user service won't find the registry service.